### PR TITLE
open game over page and winner name showed

### DIFF
--- a/client/client.py
+++ b/client/client.py
@@ -16,6 +16,7 @@ player_list = []
 question = []
 answers = []
 round = 1
+has_winner = False
 
 def receiver_runner():
     while True:
@@ -28,7 +29,7 @@ def receiver_runner():
             break
 
 def handle_message(data):
-    global player_list, question, answers, is_layout_ready, current_turn, round
+    global player_list, question, answers, is_layout_ready, current_turn, round, has_winner
     message = json.loads(data)
     print("Data receive: ", message)
     if message["token"] == "Name":
@@ -58,13 +59,18 @@ def handle_message(data):
     elif message["token"] == "Locked":
         layout.unlock_button_press()
 
-# To be binded by front-end team members
+    elif message["token"] == "Result":
+        has_winner = True
+        print("---- Get winner at client:", message["winner"])
+        set_winner_name(message["winner"])
+        # open_game_over(message["winner"])
+
 def send_message(message):
     print("Message send: ", message)
     data = json.dumps(message)
     my_socket.sendall(bytes(data,encoding="utf-8"))
 
-# Be called in lobby
+#  Called from lobby
 def start_client():
     global my_socket
     my_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -106,3 +112,12 @@ def get_round():
 def get_turn():
     return current_turn
 
+def set_winner_name(winner_token):
+    global winner_name
+    winner_name = winner_token
+
+def get_winner_name():
+    return winner_name
+
+def has_the_winner():
+    return has_winner

--- a/client/game_over.py
+++ b/client/game_over.py
@@ -1,0 +1,49 @@
+# Game over
+import pygame, sys
+import client
+from pygame.locals import *
+
+# --------- page setup ---------
+BLACK = (0,0,0)
+WHITE = (255,255,255)
+NAVYBLUE = (60,60,100) # bg color
+ORANGE = (255,128,0)
+SCREEN_WIDTH = 700
+SCREEN_HEIGHT = 500
+
+screenSize = [SCREEN_WIDTH,SCREEN_HEIGHT] 
+screen = pygame.display.set_mode(screenSize)
+
+pygame.init()
+# manage how fast the screen updates
+clock = pygame.time.Clock()
+frame_rate = 60
+
+
+def open_game_over():
+# def open_game_over(winner_param):
+    while True:
+        font_large = pygame.font.SysFont('Calibri', 25, True, False)  
+
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT or (event.type == KEYUP and event.key == K_ESCAPE):
+                pygame.quit()
+                sys.exit()
+
+        # update game state
+        pygame.display.update()
+        clock.tick(frame_rate)
+
+        screen.fill(NAVYBLUE) 
+        # ----------- Display Winner -----------
+        winner_param = client.get_winner_name()
+        title = font_large.render(f"*** Player {winner_param} Won! ***", True, ORANGE)
+        title_center = title.get_rect(center=(SCREEN_WIDTH/2, SCREEN_HEIGHT/4))
+        screen.blit(title, title_center)
+
+        # ----------- Display game over --------
+        game_over_text = font_large.render("Game over.", True, ORANGE)
+        game_over_text_center = game_over_text.get_rect(center=(SCREEN_WIDTH/2, SCREEN_HEIGHT/2))
+        screen.blit(game_over_text, game_over_text_center)
+
+    


### PR DESCRIPTION
- Once all rounds are done, and winner result is ready, game layout will swap to game over page.
- Game over page also display winner name.

- Testing on Mac OS:
![Screen Shot 2022-08-11 at 9 03 42 PM](https://user-images.githubusercontent.com/100490492/184285851-e1a49fdb-da35-4a39-a607-5621b448f01a.png)

- Testing on Windows:
![go1](https://user-images.githubusercontent.com/100490492/184286968-6e0459a4-91b8-47ba-b725-5f4d5404fb69.JPG)

